### PR TITLE
Add Phase 1 topic tracker to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,10 @@ Transition into an AI PM role within 9 months.
 - 4-6 hours per week
 - Topics studied with Claude AI as instructor
 - Progress tracked topic by topic
+
+## Phase 1 Topics
+- Topic 1: Terminal & Command Line ✅
+- Topic 2: Git & GitHub (in progress)
+- Topic 3: Python — Reading Code
+- Topic 4: APIs
+- Topic 5: How Software Gets Built


### PR DESCRIPTION
## What this PR does
Adds a Phase 1 topic tracker section to the README so progress
is visible directly from the repo homepage.

## Why
Makes it easy to track which topics are completed at a glance
without opening a separate file.

## Topics covered
- Added 5 Phase 1 topics with status indicators
- Used emoji checkmarks for visual progress tracking

## Testing
Verified README renders correctly on GitHub preview.